### PR TITLE
Expose basewidth and baseheight variables

### DIFF
--- a/template/sass.hbs
+++ b/template/sass.hbs
@@ -4,6 +4,15 @@ ${{#if ../../opt.split}}{{cssesc ../../name}}-{{/if}}{{cssesc meta.name}}: -{{ba
   {{/each}}
 {{/each}}
 
+{{#each layouts}}
+  {{#each sprites}}
+    {{#unless dpi}}
+    ${{cssesc ../../classname}}-baseWidth: {{baseWidth}}px
+    ${{cssesc ../../classname}}-baseHeight: {{baseHeight}}px
+    {{/unless}}
+  {{/each}}
+{{/each}}
+
 =sprite-width($sprite)
   width: nth($sprite, 3)
 

--- a/template/scss.hbs
+++ b/template/scss.hbs
@@ -4,6 +4,15 @@
   {{/each}}
 {{/each}}
 
+{{#each layouts}}
+  {{#each sprites}}
+    {{#unless dpi}}
+    ${{cssesc ../../classname}}-baseWidth: {{baseWidth}}px;
+    ${{cssesc ../../classname}}-baseHeight: {{baseHeight}}px;
+    {{/unless}}
+  {{/each}}
+{{/each}}
+
 @mixin sprite-width($sprite) {
   width: nth($sprite, 3);
 }


### PR DESCRIPTION
This may be a strawman approach, but what do you think about exposing baseWidth and baseHeight as sass variables?

My use-case is needing to create a `@mixin icon { }` with these props, as I can't rely on `.icon { }` class.